### PR TITLE
Fix login output issue

### DIFF
--- a/login.php
+++ b/login.php
@@ -3,7 +3,6 @@ require 'connection.php'; // Conexão com o MongoDB
 session_start();
 
 if (isset($_POST['email'])) {
-    var_dump($_POST);
     $email = $_POST['email'];
     $senha = $_POST['senha'];
     


### PR DESCRIPTION
## Summary
- remove leftover `var_dump` debugging from the login form

## Testing
- `php -l login.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6861b9487978832cbbaae3fc8e943fcb