### PR TITLE
Add Docker environment with MongoDB

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+.dockerignore
+Dockerfile
+docker-compose.yml

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/vendor/
+.env
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM php:8.3-apache
+
+# Install MongoDB extension
+RUN apt-get update && apt-get install -y \
+        libpng-dev \
+        libjpeg-dev \
+        libonig-dev \
+        libzip-dev \
+        unzip && \
+    pecl install mongodb && \
+    docker-php-ext-enable mongodb && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /var/www/html
+
+# Copy application
+COPY . /var/www/html
+
+# Set Apache DocumentRoot
+ENV APACHE_DOCUMENT_ROOT=/var/www/html
+
+RUN chown -R www-data:www-data /var/www/html
+
+EXPOSE 80
+
+CMD ["apache2-foreground"]

--- a/connection.php
+++ b/connection.php
@@ -1,4 +1,5 @@
 <?php
-// connection.php
-$manager = new MongoDB\Driver\Manager("mongodb://localhost:27017");
-?>
+$mongoHost = getenv('MONGO_HOST') ?: 'mongo';
+$mongoPort = getenv('MONGO_PORT') ?: '27017';
+$manager = new MongoDB\Driver\Manager("mongodb://{$mongoHost}:{$mongoPort}");
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: '3.8'
+
+services:
+  app:
+    build: .
+    ports:
+      - "8080:80"
+    volumes:
+      - ./:/var/www/html
+    depends_on:
+      - mongo
+
+  mongo:
+    image: mongo:latest
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongo_data:/data/db
+
+  compass:
+    image: mongodb/compass:latest
+    environment:
+      - DISPLAY=${DISPLAY}
+    volumes:
+      - /tmp/.X11-unix:/tmp/.X11-unix
+    depends_on:
+      - mongo
+
+volumes:
+  mongo_data:


### PR DESCRIPTION
## Summary
- add Dockerfile with PHP 8.3 and MongoDB extension
- create docker-compose stack with MongoDB and Compass services
- add Docker ignore and git ignore
- update MongoDB connection to use env vars

## Testing
- `php -l connection.php` *(fails: `php` not found)*
- `docker --version` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861baa0e6b0832cbcc70a2074bb99d0