### PR TITLE
Add CSRF tokens

### DIFF
--- a/create.php
+++ b/create.php
@@ -1,7 +1,9 @@
 <?php
 // create.php
+session_start();
 require 'connection.php';
-
+require 'csrf.php';
+$token = generate_csrf_token();
 
 ?>
 
@@ -100,6 +102,9 @@ require 'connection.php';
 <body>
     <?php
         if ($_SERVER["REQUEST_METHOD"] == "POST") {
+            if (!verify_csrf_token($_POST['csrf_token'] ?? '')) {
+                die('CSRF validation failed');
+            }
             // Capturar dados do formulário
             $nome = $_POST['nome'];
             $endereco = $_POST['endereco'];
@@ -123,6 +128,7 @@ require 'connection.php';
 
     <h1 class="form-title">Adicionar Novo Site</h1>
     <form action="create.php" method="post">
+      <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($token, ENT_QUOTES, 'UTF-8'); ?>" />
       <div class="form-group">
         <label for="nome">Nome do site:</label>
         <input type="text" id="nome" name="nome" required />

--- a/csrf.php
+++ b/csrf.php
@@ -1,0 +1,12 @@
+<?php
+function generate_csrf_token() {
+    if (empty($_SESSION['csrf_token'])) {
+        $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+    }
+    return $_SESSION['csrf_token'];
+}
+
+function verify_csrf_token($token) {
+    return isset($_SESSION['csrf_token']) && hash_equals($_SESSION['csrf_token'], $token);
+}
+?>

--- a/login.php
+++ b/login.php
@@ -1,8 +1,13 @@
 <?php
-require 'connection.php'; // Conexão com o MongoDB
 session_start();
+require 'connection.php'; // Conexão com o MongoDB
+require 'csrf.php';
+$token = generate_csrf_token();
 
 if (isset($_POST['email'])) {
+    if (!verify_csrf_token($_POST['csrf_token'] ?? '')) {
+        die('CSRF validation failed');
+    }
     $email = $_POST['email'];
     $senha = $_POST['senha'];
     
@@ -127,6 +132,7 @@ if (isset($_POST['email'])) {
   <div class="login-container">
     <h1 class="login-title">Login</h1>
     <form action="login.php" method="post">
+      <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($token, ENT_QUOTES, 'UTF-8'); ?>" />
       <div class="form-group">
         <label for="email">Email:</label>
         <input type="email" name="email" required />

--- a/register.php
+++ b/register.php
@@ -1,7 +1,13 @@
 <?php
+session_start();
 require 'connection.php';
+require 'csrf.php';
+$token = generate_csrf_token();
 
 if ($_SERVER["REQUEST_METHOD"] === 'POST') {
+    if (!verify_csrf_token($_POST['csrf_token'] ?? '')) {
+        die('CSRF validation failed');
+    }
     $email = $_POST['email'];
     $senha = $_POST['senha'];
 
@@ -114,6 +120,7 @@ if ($_SERVER["REQUEST_METHOD"] === 'POST') {
       <div class="message"><?= $mensagem ?></div>
     <?php endif; ?>
     <form action="register.php" method="post">
+      <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($token, ENT_QUOTES, 'UTF-8'); ?>" />
       <div class="form-group">
         <label for="email">Email:</label>
         <input type="email" name="email" required />

--- a/update.php
+++ b/update.php
@@ -1,6 +1,9 @@
 <?php
 // update.php
+session_start();
 require 'connection.php';
+require 'csrf.php';
+$token = generate_csrf_token();
 
 if (isset($_GET['id'])) {
     $id = new MongoDB\BSON\ObjectId($_GET['id']);
@@ -107,6 +110,9 @@ if (isset($_GET['id'])) {
 <body>
 <?php
 if ($_SERVER["REQUEST_METHOD"] == "POST") {
+    if (!verify_csrf_token($_POST['csrf_token'] ?? '')) {
+        die('CSRF validation failed');
+    }
     $id = new MongoDB\BSON\ObjectId($_POST['id']);
     $nome = $_POST['nome'];
     $endereco = $_POST['endereco'];
@@ -133,6 +139,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
 <div class="form-container">
     <h1 class="form-title">Editar Site</h1>
     <form action="update.php" method="post">
+      <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($token, ENT_QUOTES, 'UTF-8'); ?>" />
       <input type="hidden" name="id" value="<?= htmlspecialchars((string) $site->_id, ENT_QUOTES, 'UTF-8') ?>" />
       
       <div class="form-group">


### PR DESCRIPTION
## Summary
- add reusable CSRF helper
- protect login, register, create and update forms using CSRF tokens

## Testing
- `php -l login.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862e0e9ba94832c83392cc9c0164419