### PR TITLE
Add MongoDB error handling

### DIFF
--- a/connection.php
+++ b/connection.php
@@ -1,5 +1,11 @@
 <?php
 $mongoHost = getenv('MONGO_HOST') ?: 'mongo';
 $mongoPort = getenv('MONGO_PORT') ?: '27017';
-$manager = new MongoDB\Driver\Manager("mongodb://{$mongoHost}:{$mongoPort}");
+$manager = null;
+try {
+    $manager = new MongoDB\Driver\Manager("mongodb://{$mongoHost}:{$mongoPort}");
+} catch (\Throwable $e) {
+    error_log('MongoDB connection error: ' . $e->getMessage());
+    die('Falha ao conectar ao banco de dados.');
+}
 

--- a/create.php
+++ b/create.php
@@ -123,7 +123,12 @@ $token = generate_csrf_token();
             $bulk->insert($document);
 
             // Inserir no MongoDB
-            $manager->executeBulkWrite('catalogosites.sites', $bulk);
+            try {
+                $manager->executeBulkWrite('catalogosites.sites', $bulk);
+            } catch (\Throwable $e) {
+                error_log('MongoDB insert error: ' . $e->getMessage());
+                die('Erro ao inserir dados.');
+            }
 
             echo "<div class='message'>Site cadastrado com sucesso!</div>";
         }

--- a/delete.php
+++ b/delete.php
@@ -14,7 +14,12 @@ if (isset($_GET['id'])) {
     $bulk->delete(['_id' => $id]);
 
     // Executar a exclusão
-    $manager->executeBulkWrite('catalogosites.sites', $bulk);
+    try {
+        $manager->executeBulkWrite('catalogosites.sites', $bulk);
+    } catch (\Throwable $e) {
+        error_log('MongoDB delete error: ' . $e->getMessage());
+        die('Erro ao deletar dados.');
+    }
 
     echo "Site deletado com sucesso!";
 }

--- a/index.php
+++ b/index.php
@@ -13,7 +13,12 @@ require 'connection.php';
 $query = new MongoDB\Driver\Query([]);
 
 // Executar a consulta
-$cursor = $manager->executeQuery('catalogosites.sites', $query); // Usando "catalogo_sites"
+try {
+    $cursor = $manager->executeQuery('catalogosites.sites', $query); // Usando "catalogo_sites"
+} catch (\Throwable $e) {
+    error_log('MongoDB query error: ' . $e->getMessage());
+    die('Erro ao buscar dados.');
+}
 ?>
 
 <!DOCTYPE html>

--- a/login.php
+++ b/login.php
@@ -20,8 +20,13 @@ if (isset($_POST['email'])) {
     $query = new MongoDB\Driver\Query($filter);
 
     // Executar a consulta
-    $cursor = $manager->executeQuery('catalogosites.usuarios', $query); // Usando "catalogosites"
-    $usuario = current($cursor->toArray());
+    try {
+        $cursor = $manager->executeQuery('catalogosites.usuarios', $query); // Usando "catalogosites"
+        $usuario = current($cursor->toArray());
+    } catch (\Throwable $e) {
+        error_log('MongoDB query error: ' . $e->getMessage());
+        die('Erro ao buscar usuário.');
+    }
 
     // Verificar se o usuário foi encontrado e se a senha está correta utilizando hash
     if ($usuario && password_verify($senha, $usuario->senha)) {

--- a/read.php
+++ b/read.php
@@ -6,7 +6,12 @@ require 'connection.php';
 $query = new MongoDB\Driver\Query([]);
 
 // Executar a consulta
-$cursor = $manager->executeQuery('catalogosites.sites', $query);
+try {
+    $cursor = $manager->executeQuery('catalogosites.sites', $query);
+} catch (\Throwable $e) {
+    error_log('MongoDB query error: ' . $e->getMessage());
+    die('Erro ao buscar dados.');
+}
 
 // Exibir os resultados
 echo "<h2>Lista de Sites</h2>";

--- a/register.php
+++ b/register.php
@@ -24,7 +24,12 @@ if ($_SERVER["REQUEST_METHOD"] === 'POST') {
 
         $bulk = new MongoDB\Driver\BulkWrite;
         $bulk->insert($document);
-        $manager->executeBulkWrite('catalogosites.usuarios', $bulk);
+        try {
+            $manager->executeBulkWrite('catalogosites.usuarios', $bulk);
+        } catch (\Throwable $e) {
+            error_log('MongoDB insert error: ' . $e->getMessage());
+            die('Erro ao cadastrar usuário.');
+        }
 
         $mensagem = 'Usuário cadastrado com sucesso!';
     }

--- a/testemongo.php
+++ b/testemongo.php
@@ -11,7 +11,12 @@ $manager = new MongoDB\Driver\Manager("mongodb://localhost:27017");
 
 // Consulta para selecionar os documentos da coleção 'sites' no banco 'banco'
 $query = new MongoDB\Driver\Query([]);  // Consulta vazia para buscar todos os documentos
-$cursor = $manager->executeQuery('catalogosites.sites', $query);
+try {
+    $cursor = $manager->executeQuery('catalogosites.sites', $query);
+} catch (\Throwable $e) {
+    error_log('MongoDB query error: ' . $e->getMessage());
+    die('Erro ao executar consulta.');
+}
 
 // Exibir os resultados
 echo "<table border='1'>";

--- a/update.php
+++ b/update.php
@@ -14,8 +14,13 @@ if (isset($_GET['id'])) {
     // Localizar o registro a ser editado
     $filter = ['_id' => $id];
     $query = new MongoDB\Driver\Query($filter);
-    $cursor = $manager->executeQuery('catalogosites.sites', $query);
-    $site = current($cursor->toArray());
+    try {
+        $cursor = $manager->executeQuery('catalogosites.sites', $query);
+        $site = current($cursor->toArray());
+    } catch (\Throwable $e) {
+        error_log('MongoDB fetch error: ' . $e->getMessage());
+        die('Erro ao buscar dados.');
+    }
 }
 
 ?>
@@ -134,13 +139,23 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     );
 
     // Executar a atualização
-    $manager->executeBulkWrite('catalogosites.sites', $bulk);
+    try {
+        $manager->executeBulkWrite('catalogosites.sites', $bulk);
+    } catch (\Throwable $e) {
+        error_log('MongoDB update error: ' . $e->getMessage());
+        die('Erro ao atualizar dados.');
+    }
 
         // Localizar o registro a ser editado
     $filter = ['_id' => $id];
     $query = new MongoDB\Driver\Query($filter);
-    $cursor = $manager->executeQuery('catalogosites.sites', $query);
-    $site = current($cursor->toArray());
+    try {
+        $cursor = $manager->executeQuery('catalogosites.sites', $query);
+        $site = current($cursor->toArray());
+    } catch (\Throwable $e) {
+        error_log('MongoDB fetch error: ' . $e->getMessage());
+        die('Erro ao buscar dados.');
+    }
 
     echo "<div class='message'> Site atualizado com sucesso! </div>";
 }


### PR DESCRIPTION
## Summary
- improve connection robustness and query reliability
- wrap MongoDB calls in try/catch blocks with logging

## Testing
- `php -l connection.php` *(fails: command not found)*
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862e65ca910832ca9f562a49022524f