### PR TITLE
Refactor styles into shared stylesheet

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,0 +1,228 @@
+/* Shared styles for the CRUD application */
+
+/* Base page setup */
+body {
+  margin: 0;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  background: #f2f5f9;
+  color: #333;
+}
+
+/* Pages that need centered content (login/register/create/update) */
+.center-page {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+}
+
+.login-container {
+  background: #ffffff;
+  padding: 2.5rem 2rem;
+  border-radius: 12px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  width: 100%;
+  max-width: 400px;
+}
+
+.login-title {
+  text-align: center;
+  margin-bottom: 1.5rem;
+  font-size: 1.8rem;
+}
+
+.form-group {
+  margin-bottom: 1rem;
+}
+
+label {
+  display: block;
+  margin-bottom: 0.5rem;
+  font-weight: 600;
+}
+
+input[type="email"],
+input[type="password"],
+input[type="text"] {
+  width: 100%;
+  padding: 0.75rem;
+  border-radius: 8px;
+  border: 1px solid #ccc;
+  font-size: 1rem;
+  transition: border 0.3s ease;
+}
+
+input[type="email"]:focus,
+input[type="password"]:focus,
+input[type="text"]:focus {
+  border-color: #007bff;
+  outline: none;
+}
+
+.submit-btn {
+  width: 100%;
+  padding: 0.75rem;
+  background-color: #007bff;
+  border: none;
+  color: white;
+  font-weight: bold;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 1rem;
+  transition: background 0.3s ease;
+}
+
+.submit-btn:hover {
+  background-color: #0056b3;
+}
+
+.error-message {
+  color: #d00000;
+  margin-top: 1rem;
+  text-align: center;
+  font-weight: 500;
+}
+
+.register-link {
+  text-align: center;
+  margin-top: 1rem;
+}
+
+.register-link a {
+  color: #007bff;
+  text-decoration: none;
+}
+
+/* ----- Register Page ----- */
+.register-container {
+  background: #ffffff;
+  padding: 2.5rem 2rem;
+  border-radius: 12px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  width: 100%;
+  max-width: 400px;
+}
+
+.register-title {
+  text-align: center;
+  margin-bottom: 1.5rem;
+  font-size: 1.8rem;
+}
+
+.message {
+  color: #155724;
+  background-color: #d4edda;
+  padding: 1rem 1.5rem;
+  border-radius: 8px;
+  border: 1px solid #c3e6cb;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
+  font-size: 1rem;
+  font-weight: 500;
+  max-width: 400px;
+  text-align: center;
+  margin-bottom: 20px;
+}
+
+/* ----- Form Pages (create/update) ----- */
+.form-container {
+  background: #ffffff;
+  padding: 2rem;
+  border-radius: 12px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+  width: 100%;
+  max-width: 500px;
+}
+
+.form-title {
+  text-align: center;
+  font-size: 1.8rem;
+  margin-bottom: 1.5rem;
+}
+
+.form-group {
+  margin-bottom: 1.2rem;
+}
+
+/* ----- Index Page ----- */
+body.index-page {
+  padding: 2rem;
+}
+
+.container {
+  max-width: 900px;
+  margin: 0 auto;
+  background-color: #fff;
+  border-radius: 12px;
+  padding: 2rem;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+}
+
+.page-title {
+  font-size: 2rem;
+  margin-bottom: 1rem;
+  text-align: center;
+}
+
+.welcome-message {
+  font-size: 1rem;
+  margin-bottom: 1.5rem;
+  text-align: center;
+  color: #666;
+}
+
+.actions {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.actions a {
+  margin: 0 0.5rem;
+  text-decoration: none;
+  background-color: #007bff;
+  color: white;
+  padding: 0.5rem 1rem;
+  border-radius: 8px;
+  font-weight: bold;
+  transition: background-color 0.3s ease;
+}
+
+.actions a:hover {
+  background-color: #0056b3;
+}
+
+h2 {
+  font-size: 1.5rem;
+  margin-bottom: 1rem;
+  color: #222;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+}
+
+th,
+td {
+  padding: 0.75rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+th {
+  background-color: #f4f6fa;
+  font-weight: 600;
+  color: #333;
+}
+
+td a {
+  color: #007bff;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+td a:hover {
+  text-decoration: underline;
+}

--- a/templates/create.php
+++ b/templates/create.php
@@ -5,91 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Adicionar Site</title>
   <link rel="stylesheet" href="./css/reset.css" />
-  <style>
-    body {
-      margin: 0;
-      font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-      background-color: #f2f5f9;
-      display: flex;
-      flex-direction: column;
-      justify-content: center;
-      align-items: center;
-      min-height: 100vh;
-      color: #333;
-    }
-
-    .form-container {
-      background: #ffffff;
-      padding: 2rem;
-      border-radius: 12px;
-      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
-      width: 100%;
-      max-width: 500px;
-    }
-
-    .form-title {
-      text-align: center;
-      font-size: 1.8rem;
-      margin-bottom: 1.5rem;
-    }
-
-    .form-group {
-      margin-bottom: 1.2rem;
-    }
-
-    label {
-      display: block;
-      margin-bottom: 0.5rem;
-      font-weight: 600;
-    }
-
-    input[type="text"] {
-      width: 100%;
-      padding: 0.75rem;
-      border-radius: 8px;
-      border: 1px solid #ccc;
-      font-size: 1rem;
-      transition: border-color 0.3s ease;
-    }
-
-    input[type="text"]:focus {
-      border-color: #007bff;
-      outline: none;
-    }
-
-    .submit-btn {
-      width: 100%;
-      padding: 0.75rem;
-      background-color: #007bff;
-      color: white;
-      border: none;
-      font-weight: bold;
-      font-size: 1rem;
-      border-radius: 8px;
-      cursor: pointer;
-      transition: background 0.3s ease;
-    }
-
-    .submit-btn:hover {
-      background-color: #0056b3;
-    }
-
-    .message {
-      background-color: #d4edda;
-      color: #155724;
-      padding: 1rem 1.5rem;
-      border-radius: 8px;
-      border: 1px solid #c3e6cb;
-      box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
-      font-size: 1rem;
-      font-weight: 500;
-      max-width: 400px;
-      text-align: center;
-      margin-bottom: 20px;
-    }
-  </style>
+  <link rel="stylesheet" href="./css/style.css" />
 </head>
-<body>
+<body class="center-page">
   <?php if (!empty($message)): ?>
     <div class='message'><?= $message ?></div>
   <?php endif; ?>

--- a/templates/index.php
+++ b/templates/index.php
@@ -5,95 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Página Inicial - CRUD de Sites</title>
   <link rel="stylesheet" href="./css/reset.css" />
-  <style>
-    body {
-      margin: 0;
-      font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-      background-color: #f2f5f9;
-      padding: 2rem;
-      color: #333;
-    }
-
-    .container {
-      max-width: 900px;
-      margin: 0 auto;
-      background-color: #fff;
-      border-radius: 12px;
-      padding: 2rem;
-      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
-    }
-
-    .page-title {
-      font-size: 2rem;
-      margin-bottom: 1rem;
-      text-align: center;
-    }
-
-    .welcome-message {
-      font-size: 1rem;
-      margin-bottom: 1.5rem;
-      text-align: center;
-      color: #666;
-    }
-
-    .actions {
-      text-align: center;
-      margin-bottom: 2rem;
-    }
-
-    .actions a {
-      margin: 0 0.5rem;
-      text-decoration: none;
-      background-color: #007bff;
-      color: white;
-      padding: 0.5rem 1rem;
-      border-radius: 8px;
-      font-weight: bold;
-      transition: background-color 0.3s ease;
-    }
-
-    .actions a:hover {
-      background-color: #0056b3;
-    }
-
-    h2 {
-      font-size: 1.5rem;
-      margin-bottom: 1rem;
-      color: #222;
-    }
-
-    table {
-      width: 100%;
-      border-collapse: collapse;
-      border-radius: 8px;
-      overflow: hidden;
-      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
-    }
-
-    th, td {
-      padding: 0.75rem 1rem;
-      text-align: left;
-      border-bottom: 1px solid #e0e0e0;
-    }
-
-    th {
-      background-color: #f4f6fa;
-      font-weight: 600;
-      color: #333;
-    }
-
-    td a {
-      color: #007bff;
-      text-decoration: none;
-      font-weight: 500;
-    }
-
-    td a:hover {
-      text-decoration: underline;
-    }
-  </style>
+  <link rel="stylesheet" href="./css/style.css" />
 </head>
-<body>
+<body class="index-page">
   <div class="container">
     <h1 class="page-title">Gerenciamento de Sites</h1>
     <p class="welcome-message">Bem-vindo, <?= htmlspecialchars($email, ENT_QUOTES, 'UTF-8'); ?>!</p>

--- a/templates/login.php
+++ b/templates/login.php
@@ -5,96 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Login - CRUD de Sites</title>
   <link rel="stylesheet" href="./css/reset.css" />
-  <style>
-    body {
-      margin: 0;
-      font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-      background: #f2f5f9;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      min-height: 100vh;
-    }
-
-    .login-container {
-      background: #ffffff;
-      padding: 2.5rem 2rem;
-      border-radius: 12px;
-      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-      width: 100%;
-      max-width: 400px;
-    }
-
-    .login-title {
-      text-align: center;
-      margin-bottom: 1.5rem;
-      font-size: 1.8rem;
-      color: #333;
-    }
-
-    .form-group {
-      margin-bottom: 1rem;
-    }
-
-    label {
-      display: block;
-      margin-bottom: 0.5rem;
-      font-weight: 600;
-      color: #333;
-    }
-
-    input[type="email"],
-    input[type="password"] {
-      width: 100%;
-      padding: 0.75rem;
-      border-radius: 8px;
-      border: 1px solid #ccc;
-      font-size: 1rem;
-      transition: border 0.3s ease;
-    }
-
-    input[type="email"]:focus,
-    input[type="password"]:focus {
-      border-color: #007bff;
-      outline: none;
-    }
-
-    .submit-btn {
-      width: 100%;
-      padding: 0.75rem;
-      background-color: #007bff;
-      border: none;
-      color: white;
-      font-weight: bold;
-      border-radius: 8px;
-      cursor: pointer;
-      font-size: 1rem;
-      transition: background 0.3s ease;
-    }
-
-    .submit-btn:hover {
-      background-color: #0056b3;
-    }
-
-    .error-message {
-      color: #d00000;
-      margin-top: 1rem;
-      text-align: center;
-      font-weight: 500;
-    }
-
-    .register-link {
-      text-align: center;
-      margin-top: 1rem;
-    }
-
-    .register-link a {
-      color: #007bff;
-      text-decoration: none;
-    }
-  </style>
+  <link rel="stylesheet" href="./css/style.css" />
 </head>
-<body>
+<body class="center-page">
   <div class="login-container">
     <h1 class="login-title">Login</h1>
     <form action="login.php" method="post">

--- a/templates/register.php
+++ b/templates/register.php
@@ -5,88 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Cadastro de Usuário</title>
   <link rel="stylesheet" href="./css/reset.css" />
-  <style>
-    body {
-      margin: 0;
-      font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-      background: #f2f5f9;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      min-height: 100vh;
-    }
-
-    .register-container {
-      background: #ffffff;
-      padding: 2.5rem 2rem;
-      border-radius: 12px;
-      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-      width: 100%;
-      max-width: 400px;
-    }
-
-    .register-title {
-      text-align: center;
-      margin-bottom: 1.5rem;
-      font-size: 1.8rem;
-      color: #333;
-    }
-
-    .form-group {
-      margin-bottom: 1rem;
-    }
-
-    label {
-      display: block;
-      margin-bottom: 0.5rem;
-      font-weight: 600;
-      color: #333;
-    }
-
-    input[type="email"],
-    input[type="password"] {
-      width: 100%;
-      padding: 0.75rem;
-      border-radius: 8px;
-      border: 1px solid #ccc;
-      font-size: 1rem;
-      transition: border 0.3s ease;
-    }
-
-    input[type="email"]:focus,
-    input[type="password"]:focus {
-      border-color: #007bff;
-      outline: none;
-    }
-
-    .submit-btn {
-      width: 100%;
-      padding: 0.75rem;
-      background-color: #007bff;
-      border: none;
-      color: white;
-      font-weight: bold;
-      border-radius: 8px;
-      cursor: pointer;
-      font-size: 1rem;
-      transition: background 0.3s ease;
-    }
-
-    .submit-btn:hover {
-      background-color: #0056b3;
-    }
-
-    .message {
-      color: #155724;
-      background-color: #d4edda;
-      padding: 1rem;
-      border-radius: 8px;
-      text-align: center;
-      margin-bottom: 1rem;
-    }
-  </style>
+  <link rel="stylesheet" href="./css/style.css" />
 </head>
-<body>
+<body class="center-page">
   <div class="register-container">
     <h1 class="register-title">Cadastro</h1>
     <?php if (!empty($mensagem)) : ?>

--- a/templates/update.php
+++ b/templates/update.php
@@ -5,90 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Editar Site</title>
    <link rel="stylesheet" href="./css/reset.css" />
-  <style>
-    body {
-      margin: 0;
-      font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-      background-color: #f2f5f9;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      min-height: 100vh;
-      flex-direction: column;
-      color: #333;
-    }
-
-    .form-container {
-      background: #ffffff;
-      padding: 2rem;
-      border-radius: 12px;
-      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
-      width: 100%;
-      max-width: 500px;
-    }
-
-    .form-title {
-      text-align: center;
-      font-size: 1.8rem;
-      margin-bottom: 1.5rem;
-    }
-
-    .form-group {
-      margin-bottom: 1.2rem;
-    }
-
-    label {
-      display: block;
-      margin-bottom: 0.5rem;
-      font-weight: 600;
-    }
-
-    input[type="text"] {
-      width: 100%;
-      padding: 0.75rem;
-      border-radius: 8px;
-      border: 1px solid #ccc;
-      font-size: 1rem;
-      transition: border-color 0.3s ease;
-    }
-
-    input[type="text"]:focus {
-      border-color: #007bff;
-      outline: none;
-    }
-
-    .submit-btn {
-      width: 100%;
-      padding: 0.75rem;
-      background-color: #007bff;
-      color: white;
-      border: none;
-      font-weight: bold;
-      font-size: 1rem;
-      border-radius: 8px;
-      cursor: pointer;
-      transition: background 0.3s ease;
-    }
-
-    .submit-btn:hover {
-      background-color: #0056b3;
-    }
-    .message {
-      background-color: #d4edda;
-      color: #155724;
-      padding: 1rem 1.5rem;
-      border-radius: 8px;
-      border: 1px solid #c3e6cb;
-      box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
-      font-size: 1rem;
-      font-weight: 500;
-      max-width: 400px;
-      text-align: center;
-      margin-bottom: 20px;
-    }
-  </style>
+   <link rel="stylesheet" href="./css/style.css" />
 </head>
-<body>
+<body class="center-page">
 <?php if (!empty($message)): ?>
   <div class='message'><?= $message ?></div>
 <?php endif; ?>


### PR DESCRIPTION
## Summary
- centralize repeated CSS rules in `css/style.css`
- load the shared stylesheet in all templates and mark appropriate body classes
- remove inline style blocks from the templates

## Testing
- `php -l templates/login.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863d3883204832caf6a4ed8d921a0f3