### PR TITLE
Rename helper functions to camelCase

### DIFF
--- a/create.php
+++ b/create.php
@@ -4,11 +4,11 @@ session_start();
 require 'connection.php';
 require 'csrf.php';
 require 'template.php';
-$token = generate_csrf_token();
+$token = generateCsrfToken();
 $message = null;
 
 if ($_SERVER["REQUEST_METHOD"] == "POST") {
-    if (!verify_csrf_token($_POST['csrf_token'] ?? '')) {
+    if (!verifyCsrfToken($_POST['csrf_token'] ?? '')) {
         die('CSRF validation failed');
     }
     // Capturar dados do formulário com validação
@@ -39,7 +39,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     $message = 'Site cadastrado com sucesso!';
 }
 
-render_template('create', ['token' => $token, 'message' => $message]);
+renderTemplate('create', ['token' => $token, 'message' => $message]);
 
 ?>
 

--- a/csrf.php
+++ b/csrf.php
@@ -1,12 +1,12 @@
 <?php
-function generate_csrf_token() {
+function generateCsrfToken() {
     if (empty($_SESSION['csrf_token'])) {
         $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
     }
     return $_SESSION['csrf_token'];
 }
 
-function verify_csrf_token($token) {
+function verifyCsrfToken($token) {
     return isset($_SESSION['csrf_token']) && hash_equals($_SESSION['csrf_token'], $token);
 }
 ?>

--- a/index.php
+++ b/index.php
@@ -23,6 +23,6 @@ try {
 }
 
 $email = $_SESSION['email'];
-render_template('index', compact('sites', 'email'));
+renderTemplate('index', compact('sites', 'email'));
 ?>
 

--- a/login.php
+++ b/login.php
@@ -3,13 +3,13 @@ session_start();
 require 'connection.php'; // Conexão com o MongoDB
 require 'csrf.php';
 require 'template.php';
-$token = generate_csrf_token();
+$token = generateCsrfToken();
 $erro = null;
 
 if (isset($_POST['email'])) {
 
 
-    if (!verify_csrf_token($_POST['csrf_token'] ?? '')) {
+    if (!verifyCsrfToken($_POST['csrf_token'] ?? '')) {
         die('CSRF validation failed');
     }
     $email = filter_input(INPUT_POST, 'email', FILTER_VALIDATE_EMAIL);
@@ -43,6 +43,6 @@ if (isset($_POST['email'])) {
     }
 }}
 
-render_template('login', ['token' => $token, 'erro' => $erro]);
+renderTemplate('login', ['token' => $token, 'erro' => $erro]);
 
 ?>

--- a/register.php
+++ b/register.php
@@ -3,11 +3,11 @@ session_start();
 require 'connection.php';
 require 'csrf.php';
 require 'template.php';
-$token = generate_csrf_token();
+$token = generateCsrfToken();
 $mensagem = null;
 
 if ($_SERVER["REQUEST_METHOD"] === 'POST') {
-    if (!verify_csrf_token($_POST['csrf_token'] ?? '')) {
+    if (!verifyCsrfToken($_POST['csrf_token'] ?? '')) {
         die('CSRF validation failed');
     }
 
@@ -37,7 +37,7 @@ if ($_SERVER["REQUEST_METHOD"] === 'POST') {
     }
 }
 
-render_template('register', ['token' => $token, 'mensagem' => $mensagem]);
+renderTemplate('register', ['token' => $token, 'mensagem' => $mensagem]);
 
 ?>
 

--- a/template.php
+++ b/template.php
@@ -1,5 +1,5 @@
 <?php
-function render_template(string $template, array $vars = []): void {
+function renderTemplate(string $template, array $vars = []): void {
     extract($vars);
     include __DIR__ . '/templates/' . $template . '.php';
 }

--- a/update.php
+++ b/update.php
@@ -4,7 +4,7 @@ session_start();
 require 'connection.php';
 require 'csrf.php';
 require 'template.php';
-$token = generate_csrf_token();
+$token = generateCsrfToken();
 $message = null;
 
 if (isset($_GET['id'])) {
@@ -26,7 +26,7 @@ if (isset($_GET['id'])) {
 }
 
 if ($_SERVER["REQUEST_METHOD"] == "POST") {
-    if (!verify_csrf_token($_POST['csrf_token'] ?? '')) {
+    if (!verifyCsrfToken($_POST['csrf_token'] ?? '')) {
         die('CSRF validation failed');
     }
     $rawId = filter_input(INPUT_POST, 'id', FILTER_SANITIZE_STRING);
@@ -68,7 +68,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     $message = 'Site atualizado com sucesso!';
 }
 
-render_template('update', compact('token', 'site', 'message'));
+renderTemplate('update', compact('token', 'site', 'message'));
 
 ?>
 


### PR DESCRIPTION
## Summary
- follow PSR-1 by using camelCase
- update all calls to new function names

## Testing
- `php -l` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863dd45d400832c9a2108aef4b39d4a