### PR TITLE
Add composer usage to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ The repository is organized so that all PHP source code resides in the `src` dir
 
 - Docker
 - Docker Compose
+- Composer
+
+## Composer Setup
+
+Run `composer install` in the project root to generate the `vendor`
+directory and the autoloader that the application relies on. If you add new
+classes under `src`, run `composer dump-autoload` to refresh the autoload
+mapping.
 
 ## Running the Application
 


### PR DESCRIPTION
## Summary
- document Composer as a prerequisite
- explain how to install dependencies and refresh the autoloader

## Testing
- `composer --version` *(fails: command not found)*
- `php -l src/index.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686423234d50832c94cfe05ffa802bb2